### PR TITLE
Pin PyJWT version to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-PyJWT = "^2.2.0"
+PyJWT = "2.1.0"
 aiohttp = "^3.7.4"
 python = "^3.8.0"
 pytz = "^2021.3"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-PyJWT==2.2.0
+PyJWT==2.1.0
 aiohttp>=3.7.4.post0
 aresponses==2.1.4
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR pins `PyJWT` to `2.1.0` (since Home Assistant pins this version and this library's primary use case is to support Home Assistant).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
