### PR TITLE
Rename `special` property to `rotating`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Likewise, the `RidwellPickup` object comes with some useful properties:
 * `priority`: the pickup priority
 * `product_id`: the Ridwell ID for this particular product
 * `quantity`: the amount of the product being picked up
-* `special`: whether this is a special, "once every so often" pickup
+* `rotating`: whether this is a rotating pickup type
 
 ### Calculating a Pickup Event's Esimated Cost
 

--- a/aioridwell/client.py
+++ b/aioridwell/client.py
@@ -111,11 +111,11 @@ class RidwellPickup:
     priority: int
     product_id: str
     quantity: int
-    special: bool = field(init=False)
+    rotating: bool = field(init=False)
 
     def __post_init__(self) -> None:
         """Perform some post-init init."""
-        object.__setattr__(self, "special", self.category not in STANDARD_PICKUP_TYPES)
+        object.__setattr__(self, "rotating", self.category not in STANDARD_PICKUP_TYPES)
 
 
 @dataclass(frozen=True)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -103,13 +103,13 @@ async def test_get_pickup_events(
         assert pickup_events[0].pickups[0].priority == 1
         assert pickup_events[0].pickups[0].product_id == "pickupProduct1"
         assert pickup_events[0].pickups[0].quantity == 1
-        assert pickup_events[0].pickups[0].special is False
+        assert pickup_events[0].pickups[0].rotating is False
         assert pickup_events[0].pickups[1].category == "Chocolate"
         assert pickup_events[0].pickups[1].offer_id == "pickupOffer2"
         assert pickup_events[0].pickups[1].priority == 2
         assert pickup_events[0].pickups[1].product_id == "pickupProduct2"
         assert pickup_events[0].pickups[1].quantity == 1
-        assert pickup_events[0].pickups[1].special is True
+        assert pickup_events[0].pickups[1].rotating is True
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR changes the `special` property of the `RidwellPickup` class to `rotating` (more consistent with Ridwell's nomenclature).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
