### PR TITLE
Better debug message when firing request

### DIFF
--- a/aioridwell/client.py
+++ b/aioridwell/client.py
@@ -288,7 +288,9 @@ class Client:  # pylint: disable=too-many-instance-attributes
             await session.close()
 
         LOGGER.debug(
-            "Received data (query: %s): %s", kwargs.get("json", {}).get("query"), data
+            "Received data (operation: %s): %s",
+            kwargs.get("json", {}).get("operationName"),
+            data,
         )
 
         return data


### PR DESCRIPTION
**Describe what the PR does:**

The `DEBUG`-level logger was showing the query strings in all of their newline'd gore. This PR slims things down.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
