### PR TITLE
Make pickup type categories more granular

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ The `RidwellPickupEvent` object comes with some useful properties:
 
 Likewise, the `RidwellPickup` object comes with some useful properties:
 
-* `category`: the type of waste being picked up
+* `category`: the category of the pickup (`standard`, `rotating`, or `add_on`)
+* `name`: the name of the item being picked up
 * `offer_id`: the Ridwell ID for this particular offer
 * `priority`: the pickup priority
 * `product_id`: the Ridwell ID for this particular product
 * `quantity`: the amount of the product being picked up
-* `rotating`: whether this is a rotating pickup type
 
 ### Calculating a Pickup Event's Esimated Cost
 

--- a/aioridwell/client.py
+++ b/aioridwell/client.py
@@ -35,6 +35,9 @@ CATEGORY_ADD_ON = "add_on"
 CATEGORY_ROTATING = "rotating"
 CATEGORY_STANDARD = "standard"
 
+EVENT_STATE_INITIALIIZED = "initialized"
+EVENT_STATE_SCHEDULED = "scheduled"
+
 PICKUP_TYPES_ADD_ON = [
     "Beyond the Bin",
     "Fluorescent Light Tubes",
@@ -118,7 +121,7 @@ class RidwellPickup:
     product_id: str
     quantity: int
 
-    category: str = field(init=False)
+    category: Literal["add_on", "rotating", "standard"] = field(init=False)
 
     def __post_init__(self) -> None:
         """Perform some post-init init."""

--- a/aioridwell/client.py
+++ b/aioridwell/client.py
@@ -31,15 +31,21 @@ DEFAULT_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1
 DEFAULT_TIMEOUT = 10
 
-STANDARD_PICKUP_TYPES = [
-    "Batteries",
+CATEGORY_ADD_ON = "add_on"
+CATEGORY_ROTATING = "rotating"
+CATEGORY_STANDARD = "standard"
+
+PICKUP_TYPES_ADD_ON = [
     "Beyond the Bin",
     "Fluorescent Light Tubes",
     "Latex Paint",
-    "Light Bulbs",
     "Paint",
-    "Plastic Film",
     "Styrofoam",
+]
+PICKUP_TYPES_STANDARD = [
+    "Batteries",
+    "Light Bulbs",
+    "Plastic Film",
     "Threads",
 ]
 
@@ -106,16 +112,23 @@ class RidwellAccount:  # pylint: disable=too-many-instance-attributes
 class RidwellPickup:
     """Define a Ridwell pickup (i.e., the thing being picked up)."""
 
-    category: str
+    name: str
     offer_id: str
     priority: int
     product_id: str
     quantity: int
-    rotating: bool = field(init=False)
+
+    category: str = field(init=False)
 
     def __post_init__(self) -> None:
         """Perform some post-init init."""
-        object.__setattr__(self, "rotating", self.category not in STANDARD_PICKUP_TYPES)
+        if self.name in PICKUP_TYPES_ADD_ON:
+            category = CATEGORY_ADD_ON
+        elif self.name in PICKUP_TYPES_STANDARD:
+            category = CATEGORY_STANDARD
+        else:
+            category = CATEGORY_ROTATING
+        object.__setattr__(self, "category", category)
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/upcoming_subscription_pickups_response.json
+++ b/tests/fixtures/upcoming_subscription_pickups_response.json
@@ -12,7 +12,7 @@
 								"id": "pickupOffer1",
 								"priority": 1,
 								"category": {
-									"name": "Beyond the Bin"
+									"name": "Threads"
 								}
 							},
 							"pickupProduct": {
@@ -25,13 +25,28 @@
 						"pickupOfferPickupProduct": {
 							"pickupOffer": {
 								"id": "pickupOffer2",
+								"priority": 1,
+								"category": {
+									"name": "Beyond the Bin"
+								}
+							},
+							"pickupProduct": {
+								"id": "pickupProduct2"
+							}
+						},
+						"quantity": 2
+					},
+					{
+						"pickupOfferPickupProduct": {
+							"pickupOffer": {
+								"id": "pickupOffer3",
 								"priority": 2,
 								"category": {
 									"name": "Chocolate"
 								}
 							},
 							"pickupProduct": {
-								"id": "pickupProduct2"
+								"id": "pickupProduct3"
 							}
 						},
 						"quantity": 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -97,19 +97,25 @@ async def test_get_pickup_events(
         assert pickup_events[1].pickup_date == date(2021, 10, 27)
         assert pickup_events[1].state == "initialized"
 
-        assert len(pickup_events[0].pickups) == 2
-        assert pickup_events[0].pickups[0].category == "Beyond the Bin"
+        assert len(pickup_events[0].pickups) == 3
+        assert pickup_events[0].pickups[0].name == "Threads"
         assert pickup_events[0].pickups[0].offer_id == "pickupOffer1"
         assert pickup_events[0].pickups[0].priority == 1
         assert pickup_events[0].pickups[0].product_id == "pickupProduct1"
         assert pickup_events[0].pickups[0].quantity == 1
-        assert pickup_events[0].pickups[0].rotating is False
-        assert pickup_events[0].pickups[1].category == "Chocolate"
+        assert pickup_events[0].pickups[0].category == "standard"
+        assert pickup_events[0].pickups[1].name == "Beyond the Bin"
         assert pickup_events[0].pickups[1].offer_id == "pickupOffer2"
-        assert pickup_events[0].pickups[1].priority == 2
+        assert pickup_events[0].pickups[1].priority == 1
         assert pickup_events[0].pickups[1].product_id == "pickupProduct2"
-        assert pickup_events[0].pickups[1].quantity == 1
-        assert pickup_events[0].pickups[1].rotating is True
+        assert pickup_events[0].pickups[1].quantity == 2
+        assert pickup_events[0].pickups[1].category == "add_on"
+        assert pickup_events[0].pickups[2].name == "Chocolate"
+        assert pickup_events[0].pickups[2].offer_id == "pickupOffer3"
+        assert pickup_events[0].pickups[2].priority == 2
+        assert pickup_events[0].pickups[2].product_id == "pickupProduct3"
+        assert pickup_events[0].pickups[2].quantity == 1
+        assert pickup_events[0].pickups[2].category == "rotating"
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

I realize that consumers could benefit from a bit more granularity in understanding what a `RidwellPickup`'s category is. This PR introduces three possible values that are consistent with Ridwell's nomenclature:

* `standard`: comes every pickup
* `rotating`: a unique pickup
* `add_on`: pickup types that can be added for a fee

Not calling this a breaking change because this library is so new and isn't used anywhere outside my control yet.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
