### PR TITLE
Re-work pinned version range for aiohttp and PyJWT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-PyJWT = "2.3.0"
-aiohttp = "^3.7.4"
+PyJWT = ">=2.1.0"
+aiohttp = ">=3.8.0"
 python = "^3.8.0"
 pytz = "^2021.3"
 titlecase = "^2.3"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 PyJWT==2.1.0
-aiohttp>=3.7.4.post0
+aiohttp>=3.8.0
 aresponses==2.1.4
 freezegun==1.1.0
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR expands the pinned version range for `aiohttp` and `PyJWT`.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
