### PR TITLE
Add ability to opt into/out of pickup events

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ async def main() -> None:
     accounts = await client.async_get_accounts()
     for account in accounts.values():
         events = await account.async_get_pickup_events()
+        # >>> [RidwellPickupEvent(...), ...]
+
         event_1_cost = await events[0].async_get_estimated_cost()
         # >>> 22.00
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install aioridwell
 `aioridwell` is currently supported on:
 
 * Python 3.8
-* Python 3.9 
+* Python 3.9
 * Python 3.10
 
 # Usage
@@ -143,9 +143,30 @@ Likewise, the `RidwellPickup` object comes with some useful properties:
 * `product_id`: the Ridwell ID for this particular product
 * `quantity`: the amount of the product being picked up
 
-### Calculating a Pickup Event's Esimated Cost
+### Opting Into or Out Of a Pickup Event
 
-Calculating the estimated cost of a pickup event is, you guessed it, easy:
+```python
+import asyncio
+
+from aioridwell import async_get_client
+
+
+async def main() -> None:
+    client = await async_get_client("<EMAIL>", "<PASSWORD>")
+
+    accounts = await client.async_get_accounts()
+    for account in accounts.values():
+        events = await account.async_get_pickup_events()
+        # >>> [RidwellPickupEvent(...), ...]
+
+        await events[0].async_opt_in()
+        await events[0].async_opt_out()
+
+
+asyncio.run(main())
+```
+
+### Calculating a Pickup Event's Esimated Cost
 
 ```python
 import asyncio

--- a/aioridwell/client.py
+++ b/aioridwell/client.py
@@ -2,184 +2,27 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
-from datetime import date, datetime
-from typing import Any, Callable, Dict, Literal, TypedDict, cast
+from typing import Any, Dict, cast
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError, ContentTypeError
 import jwt
-from titlecase import titlecase
 
 from .const import LOGGER
 from .errors import (
     InvalidCredentialsError,
     RequestError,
-    RidwellError,
     TokenExpiredError,
     raise_for_data_error,
 )
-from .query import (
-    QUERY_ACCOUNT_DATA,
-    QUERY_AUTH_DATA,
-    QUERY_SUBSCRIPTION_PICKUP_QUOTE,
-    QUERY_SUBSCRIPTION_PICKUPS,
-)
+from .model import RidwellAccount
+from .query import QUERY_ACCOUNT_DATA, QUERY_AUTH_DATA
 
 API_BASE_URL = "https://api.ridwell.com"
 
 DEFAULT_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1
 DEFAULT_TIMEOUT = 10
-
-CATEGORY_ADD_ON = "add_on"
-CATEGORY_ROTATING = "rotating"
-CATEGORY_STANDARD = "standard"
-
-EVENT_STATE_INITIALIIZED = "initialized"
-EVENT_STATE_SCHEDULED = "scheduled"
-
-PICKUP_TYPES_ADD_ON = [
-    "Beyond the Bin",
-    "Fluorescent Light Tubes",
-    "Latex Paint",
-    "Paint",
-    "Styrofoam",
-]
-PICKUP_TYPES_STANDARD = [
-    "Batteries",
-    "Light Bulbs",
-    "Plastic Film",
-    "Threads",
-]
-
-
-class AddressType(TypedDict):
-    """Define a type to represent an address."""
-
-    street1: str
-    city: str
-    state: str
-    postal_code: str
-
-
-@dataclass(frozen=True)
-class RidwellAccount:  # pylint: disable=too-many-instance-attributes
-    """Define a Ridwell account."""
-
-    _async_request: Callable = field(compare=False)
-
-    account_id: str
-    address: AddressType
-    email: str
-    full_name: str
-    phone: str
-    subscription_id: str
-    subscription_active: bool
-
-    async def async_get_next_pickup_event(self) -> RidwellPickupEvent:
-        """Get the next pickup event based on today's date."""
-        pickup_events = await self.async_get_pickup_events()
-        for event in pickup_events:
-            if event.pickup_date >= date.today():
-                return event
-        raise RidwellError("No pickup events found after today")
-
-    async def async_get_pickup_events(self) -> list[RidwellPickupEvent]:
-        """Get pickup events for this subscription."""
-        resp = await self._async_request(
-            json={
-                "operationName": "upcomingSubscriptionPickups",
-                "variables": {"subscriptionId": self.subscription_id},
-                "query": QUERY_SUBSCRIPTION_PICKUPS,
-            },
-        )
-
-        return [
-            RidwellPickupEvent(
-                self._async_request,
-                event_data["id"],
-                datetime.strptime(event_data["pickupOn"], "%Y-%m-%d").date(),
-                [
-                    RidwellPickup(
-                        titlecase(
-                            pickup["pickupOfferPickupProduct"]["pickupOffer"][
-                                "category"
-                            ]["name"]
-                        ),
-                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["id"],
-                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["priority"],
-                        pickup["pickupOfferPickupProduct"]["pickupProduct"]["id"],
-                        pickup["quantity"],
-                    )
-                    for pickup in event_data["pickupProductSelections"]
-                ],
-                event_data["state"],
-            )
-            for event_data in resp["data"]["upcomingSubscriptionPickups"]
-        ]
-
-
-@dataclass(frozen=True)
-class RidwellPickup:
-    """Define a Ridwell pickup (i.e., the thing being picked up)."""
-
-    name: str
-    offer_id: str
-    priority: int
-    product_id: str
-    quantity: int
-
-    category: Literal["add_on", "rotating", "standard"] = field(init=False)
-
-    def __post_init__(self) -> None:
-        """Perform some post-init init."""
-        if self.name in PICKUP_TYPES_ADD_ON:
-            category = CATEGORY_ADD_ON
-        elif self.name in PICKUP_TYPES_STANDARD:
-            category = CATEGORY_STANDARD
-        else:
-            category = CATEGORY_ROTATING
-        object.__setattr__(self, "category", category)
-
-
-@dataclass(frozen=True)
-class RidwellPickupEvent:
-    """Define a Ridwell pickup event."""
-
-    _async_request: Callable = field(compare=False)
-    _event_id: str
-
-    pickup_date: date
-    pickups: list[RidwellPickup]
-    state: Literal["initialized", "scheduled"]
-
-    async def async_get_estimated_cost(self) -> float:
-        """Get the estimated cost (USD) of this pickup based on its pickup types."""
-        if not self.pickups:
-            return 0.0
-
-        resp = await self._async_request(
-            json={
-                "operationName": "subscriptionPickupQuote",
-                "variables": {
-                    "input": {
-                        "subscriptionPickupId": self._event_id,
-                        "addOnSelections": [
-                            {
-                                "productId": pickup.product_id,
-                                "offerId": pickup.offer_id,
-                                "quantity": pickup.quantity,
-                            }
-                            for pickup in self.pickups
-                        ],
-                    }
-                },
-                "query": QUERY_SUBSCRIPTION_PICKUP_QUOTE,
-            },
-        )
-
-        return cast(float, resp["data"]["subscriptionPickupQuote"]["totalCents"] / 100)
 
 
 def decode_jwt(encoded_jwt: str) -> dict[str, Any]:

--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -168,7 +168,7 @@ class RidwellPickupEvent:
 
         new = data["data"]["updateSubscriptionPickup"]["subscriptionPickup"]["state"]
         if new != raw_state:
-            LOGGER.warning("Ridwell returned unknown pickup event state: %s")
+            LOGGER.warning("Ridwell returned unknown pickup event state: %s", new)
             self.state = EventState.UNKNOWN
             return
 

--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -1,0 +1,191 @@
+"""Define data models for various Ridwell objects."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Callable, Literal, TypedDict, cast
+
+from titlecase import titlecase
+
+from .errors import RidwellError
+from .query import (
+    QUERY_SUBSCRIPTION_PICKUP_QUOTE,
+    QUERY_SUBSCRIPTION_PICKUPS,
+    QUERY_UPDATE_SUBSCRIPTION_PICKUP,
+)
+
+CATEGORY_ADD_ON = "add_on"
+CATEGORY_ROTATING = "rotating"
+CATEGORY_STANDARD = "standard"
+
+PICKUP_TYPES_ADD_ON = [
+    "Beyond the Bin",
+    "Fluorescent Light Tubes",
+    "Latex Paint",
+    "Paint",
+    "Styrofoam",
+]
+PICKUP_TYPES_STANDARD = [
+    "Batteries",
+    "Light Bulbs",
+    "Plastic Film",
+    "Threads",
+]
+
+
+class AddressType(TypedDict):
+    """Define a type to represent an address."""
+
+    street1: str
+    city: str
+    state: str
+    postal_code: str
+
+
+@dataclass(frozen=True)
+class RidwellAccount:  # pylint: disable=too-many-instance-attributes
+    """Define a Ridwell account."""
+
+    _async_request: Callable = field(compare=False)
+
+    account_id: str
+    address: AddressType
+    email: str
+    full_name: str
+    phone: str
+    subscription_id: str
+    subscription_active: bool
+
+    async def async_get_next_pickup_event(self) -> RidwellPickupEvent:
+        """Get the next pickup event based on today's date."""
+        pickup_events = await self.async_get_pickup_events()
+        for event in pickup_events:
+            if event.pickup_date >= date.today():
+                return event
+        raise RidwellError("No pickup events found after today")
+
+    async def async_get_pickup_events(self) -> list[RidwellPickupEvent]:
+        """Get pickup events for this subscription."""
+        resp = await self._async_request(
+            json={
+                "operationName": "upcomingSubscriptionPickups",
+                "variables": {"subscriptionId": self.subscription_id},
+                "query": QUERY_SUBSCRIPTION_PICKUPS,
+            },
+        )
+
+        return [
+            RidwellPickupEvent(
+                self._async_request,
+                event_data["id"],
+                datetime.strptime(event_data["pickupOn"], "%Y-%m-%d").date(),
+                [
+                    RidwellPickup(
+                        titlecase(
+                            pickup["pickupOfferPickupProduct"]["pickupOffer"][
+                                "category"
+                            ]["name"]
+                        ),
+                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["id"],
+                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["priority"],
+                        pickup["pickupOfferPickupProduct"]["pickupProduct"]["id"],
+                        pickup["quantity"],
+                    )
+                    for pickup in event_data["pickupProductSelections"]
+                ],
+                event_data["state"],
+            )
+            for event_data in resp["data"]["upcomingSubscriptionPickups"]
+        ]
+
+
+@dataclass(frozen=True)
+class RidwellPickup:
+    """Define a Ridwell pickup (i.e., the thing being picked up)."""
+
+    name: str
+    offer_id: str
+    priority: int
+    product_id: str
+    quantity: int
+
+    category: Literal["add_on", "rotating", "standard"] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Perform some post-init init."""
+        if self.name in PICKUP_TYPES_ADD_ON:
+            category = CATEGORY_ADD_ON
+        elif self.name in PICKUP_TYPES_STANDARD:
+            category = CATEGORY_STANDARD
+        else:
+            category = CATEGORY_ROTATING
+        object.__setattr__(self, "category", category)
+
+
+@dataclass(frozen=True)
+class RidwellPickupEvent:
+    """Define a Ridwell pickup event."""
+
+    _async_request: Callable = field(compare=False)
+
+    event_id: str
+    pickup_date: date
+    pickups: list[RidwellPickup]
+    state: Literal["initialized", "scheduled"]
+
+    async def async_get_estimated_cost(self) -> float:
+        """Get the estimated cost (USD) of this pickup based on its pickup types."""
+        if not self.pickups:
+            return 0.0
+
+        resp = await self._async_request(
+            json={
+                "operationName": "subscriptionPickupQuote",
+                "variables": {
+                    "input": {
+                        "subscriptionPickupId": self.event_id,
+                        "addOnSelections": [
+                            {
+                                "productId": pickup.product_id,
+                                "offerId": pickup.offer_id,
+                                "quantity": pickup.quantity,
+                            }
+                            for pickup in self.pickups
+                        ],
+                    }
+                },
+                "query": QUERY_SUBSCRIPTION_PICKUP_QUOTE,
+            },
+        )
+
+        return cast(float, resp["data"]["subscriptionPickupQuote"]["totalCents"] / 100)
+
+    async def async_opt_in(self) -> None:
+        """Opt in to the pickup event."""
+        await self._async_request(
+            json={
+                "operationName": "updateSubscriptionPickup",
+                "variables": {
+                    "input": {
+                        "subscriptionPickupId": self.event_id,
+                        "state": "scheduled",
+                    }
+                },
+                "query": QUERY_UPDATE_SUBSCRIPTION_PICKUP,
+            },
+        )
+
+    async def async_opt_out(self) -> None:
+        """Opt out from the pickup event."""
+        await self._async_request(
+            json={
+                "operationName": "updateSubscriptionPickup",
+                "variables": {
+                    "input": {
+                        "subscriptionPickupId": self.event_id,
+                        "state": "skipped",
+                    }
+                },
+                "query": QUERY_UPDATE_SUBSCRIPTION_PICKUP,
+            },
+        )

--- a/aioridwell/query.py
+++ b/aioridwell/query.py
@@ -62,3 +62,16 @@ query upcomingSubscriptionPickups($subscriptionId: ID!) {
   }
 }
 """
+
+QUERY_UPDATE_SUBSCRIPTION_PICKUP = """
+mutation updateSubscriptionPickup($input: UpdateSubscriptionPickupInput!) {
+  updateSubscriptionPickup(input: $input) {
+    subscriptionPickup {
+      id
+      type
+      state
+      pickupOn
+    }
+  }
+}
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,12 @@ def upcoming_subscription_pickups_response_fixture():
     return json.loads(load_fixture("upcoming_subscription_pickups_response.json"))
 
 
+@pytest.fixture(name="update_subscription_pickup_response", scope="session")
+def update_subscription_pickup_response_fixture():
+    """Define a fixture to return a response to opt in to a pickup event."""
+    return json.loads(load_fixture("update_subscription_pickup_response.json"))
+
+
 @pytest.fixture(name="user_response", scope="session")
 def user_response_fixture():
     """Define a fixture to return an user info response."""

--- a/tests/fixtures/update_subscription_pickup_response.json
+++ b/tests/fixtures/update_subscription_pickup_response.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "updateSubscriptionPickup": {
+      "subscriptionPickup": {
+        "id": "pickup1",
+        "type": "core",
+        "state": "scheduled",
+        "pickupOn": "2021-12-22"
+      }
+    }
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -389,7 +389,10 @@ async def test_opt_in(
         assert pickup_events[0].state == EventState.SKIPPED
 
         await pickup_events[0].async_opt_in()
-        assert any("unknown pickup event state" in e.message for e in caplog.records)
+        assert any(
+            "unknown pickup event state: fake_state" in e.message
+            for e in caplog.records
+        )
         assert pickup_events[0].state == EventState.UNKNOWN
 
     aresponses.assert_plan_strictly_followed()


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the ability to opt into or out of a pickup event (without editing quantities or any other ancillary info).

**Does this fix a specific issue?**

Fixes #17 
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
