### PR TITLE
Store pickup event states as enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The `RidwellPickupEvent` object comes with some useful properties:
 
 * `pickup_date`: the date of the pickup (in `datetime.date` format)
 * `pickups`: a list of `RidwellPickup` objects
-* `state`: either `initialized` (not scheduled for pickup) or `scheduled`
+* `state`: an `EventState` enum whose name represents the current state of the pickup event
 
 Likewise, the `RidwellPickup` object comes with some useful properties:
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -96,7 +96,7 @@ async def test_get_next_pickup_event(
 
         pickup_event = await account.async_get_next_pickup_event()
         assert pickup_event.pickup_date == date(2021, 10, 13)
-        assert pickup_event.state == "scheduled"
+        assert pickup_event.state == EventState.SCHEDULED
 
         assert len(pickup_event.pickups) == 3
         assert pickup_event.pickups[0].name == "Threads"
@@ -213,9 +213,9 @@ async def test_get_pickup_events(
         pickup_events = await account.async_get_pickup_events()
         assert len(pickup_events) == 2
         assert pickup_events[0].pickup_date == date(2021, 10, 13)
-        assert pickup_events[0].state == "scheduled"
+        assert pickup_events[0].state == EventState.SCHEDULED
         assert pickup_events[1].pickup_date == date(2021, 10, 27)
-        assert pickup_events[1].state == "initialized"
+        assert pickup_events[1].state == EventState.INITIALIZED
 
         assert len(pickup_events[0].pickups) == 3
         assert pickup_events[0].pickups[0].name == "Threads"
@@ -390,7 +390,7 @@ async def test_opt_in(
 
         await pickup_events[0].async_opt_in()
         assert any(
-            "unknown pickup event state: fake_state" in e.message
+            "Unknown pickup event state: fake_state" in e.message
             for e in caplog.records
         )
         assert pickup_events[0].state == EventState.UNKNOWN


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that pickup event states are stored as enums instead of loose strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
