### PR TITLE
Category enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The `RidwellPickupEvent` object comes with some useful properties:
 
 Likewise, the `RidwellPickup` object comes with some useful properties:
 
-* `category`: the category of the pickup (`standard`, `rotating`, or `add_on`)
+* `category`: a `PickupCategory` enum whose name represents the type of pickup
 * `name`: the name of the item being picked up
 * `offer_id`: the Ridwell ID for this particular offer
 * `priority`: the pickup priority

--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -16,10 +16,6 @@ from .query import (
     QUERY_UPDATE_SUBSCRIPTION_PICKUP,
 )
 
-CATEGORY_ADD_ON = "add_on"
-CATEGORY_ROTATING = "rotating"
-CATEGORY_STANDARD = "standard"
-
 PICKUP_TYPES_ADD_ON = [
     "Beyond the Bin",
     "Fluorescent Light Tubes",
@@ -60,6 +56,14 @@ def convert_pickup_event_state(state: str) -> EventState:
     except KeyError:
         LOGGER.warning("Unknown pickup event state: %s", state)
         return EventState.UNKNOWN
+
+
+class PickupCategory(Enum):
+    """Define a representation of a pickup category."""
+
+    ADD_ON = 1
+    ROTATING = 2
+    STANDARD = 3
 
 
 @dataclass(frozen=True)
@@ -134,11 +138,11 @@ class RidwellPickup:
     def __post_init__(self) -> None:
         """Perform some post-init init."""
         if self.name in PICKUP_TYPES_ADD_ON:
-            category = CATEGORY_ADD_ON
+            category = PickupCategory.ADD_ON
         elif self.name in PICKUP_TYPES_STANDARD:
-            category = CATEGORY_STANDARD
+            category = PickupCategory.STANDARD
         else:
-            category = CATEGORY_ROTATING
+            category = PickupCategory.ROTATING
         object.__setattr__(self, "category", category)
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,7 +7,7 @@ import pytest
 
 from aioridwell import async_get_client
 from aioridwell.errors import RidwellError
-from aioridwell.model import EventState
+from aioridwell.model import EventState, PickupCategory
 
 
 @pytest.mark.asyncio
@@ -104,19 +104,19 @@ async def test_get_next_pickup_event(
         assert pickup_event.pickups[0].priority == 1
         assert pickup_event.pickups[0].product_id == "pickupProduct1"
         assert pickup_event.pickups[0].quantity == 1
-        assert pickup_event.pickups[0].category == "standard"
+        assert pickup_event.pickups[0].category == PickupCategory.STANDARD
         assert pickup_event.pickups[1].name == "Beyond the Bin"
         assert pickup_event.pickups[1].offer_id == "pickupOffer2"
         assert pickup_event.pickups[1].priority == 1
         assert pickup_event.pickups[1].product_id == "pickupProduct2"
         assert pickup_event.pickups[1].quantity == 2
-        assert pickup_event.pickups[1].category == "add_on"
+        assert pickup_event.pickups[1].category == PickupCategory.ADD_ON
         assert pickup_event.pickups[2].name == "Chocolate"
         assert pickup_event.pickups[2].offer_id == "pickupOffer3"
         assert pickup_event.pickups[2].priority == 2
         assert pickup_event.pickups[2].product_id == "pickupProduct3"
         assert pickup_event.pickups[2].quantity == 1
-        assert pickup_event.pickups[2].category == "rotating"
+        assert pickup_event.pickups[2].category == PickupCategory.ROTATING
 
     aresponses.assert_plan_strictly_followed()
 
@@ -223,19 +223,19 @@ async def test_get_pickup_events(
         assert pickup_events[0].pickups[0].priority == 1
         assert pickup_events[0].pickups[0].product_id == "pickupProduct1"
         assert pickup_events[0].pickups[0].quantity == 1
-        assert pickup_events[0].pickups[0].category == "standard"
+        assert pickup_events[0].pickups[0].category == PickupCategory.STANDARD
         assert pickup_events[0].pickups[1].name == "Beyond the Bin"
         assert pickup_events[0].pickups[1].offer_id == "pickupOffer2"
         assert pickup_events[0].pickups[1].priority == 1
         assert pickup_events[0].pickups[1].product_id == "pickupProduct2"
         assert pickup_events[0].pickups[1].quantity == 2
-        assert pickup_events[0].pickups[1].category == "add_on"
+        assert pickup_events[0].pickups[1].category == PickupCategory.ADD_ON
         assert pickup_events[0].pickups[2].name == "Chocolate"
         assert pickup_events[0].pickups[2].offer_id == "pickupOffer3"
         assert pickup_events[0].pickups[2].priority == 2
         assert pickup_events[0].pickups[2].product_id == "pickupProduct3"
         assert pickup_events[0].pickups[2].quantity == 1
-        assert pickup_events[0].pickups[2].category == "rotating"
+        assert pickup_events[0].pickups[2].category == PickupCategory.ROTATING
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that pickup categories are stored as enums instead of loose strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
