### PR TITLE
Re-establish RidwellPickupEvent as frozen dataclass

### DIFF
--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -146,7 +146,7 @@ class RidwellPickup:
         object.__setattr__(self, "category", category)
 
 
-@dataclass()
+@dataclass(frozen=True)
 class RidwellPickupEvent:
     """Define a Ridwell pickup event."""
 
@@ -174,8 +174,12 @@ class RidwellPickupEvent:
             },
         )
 
-        self.state = convert_pickup_event_state(
-            data["data"]["updateSubscriptionPickup"]["subscriptionPickup"]["state"]
+        object.__setattr__(
+            self,
+            "state",
+            convert_pickup_event_state(
+                data["data"]["updateSubscriptionPickup"]["subscriptionPickup"]["state"]
+            ),
         )
 
     async def async_get_estimated_cost(self) -> float:


### PR DESCRIPTION
**Describe what the PR does:**

#18 mistakenly altered the `RidwellPickupEvent` dataclass's "frozen" status. To make things consistent (and to prevent manually altering the pickup state), this PR re-establishes it.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
