### PR TITLE
Log anytime a "presumed to be rotating" pickup type is detected

### DIFF
--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -136,6 +136,17 @@ class RidwellPickup:
 
     def __post_init__(self) -> None:
         """Perform some post-init init."""
+        category = PICKUP_CATEGORIES_MAP.get(self.name, PickupCategory.ROTATING)
+
+        if category == PickupCategory.ROTATING:
+            # Since our method of detecting rotating pickups is pretty "loose" (i.e.,
+            # if a category isn't a known standard or add-on, we assume it's rotating).
+            # This could lead to future issues if Ridwell introduces a new standard
+            # or add-on type that isn't mapped here. We try to be unintrusive and
+            # merely log that we've found a "rotating" pickup so that it can later tell
+            # the full story:
+            LOGGER.info("Detected assumed rotating pickup: %s", self.name)
+
         object.__setattr__(
             self,
             "category",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,6 @@
 """Define tests for the client."""
 from datetime import date
+import logging
 
 import aiohttp
 from freezegun import freeze_time
@@ -57,10 +58,13 @@ async def test_get_accounts(aresponses, authentication_response, user_response):
 async def test_get_next_pickup_event(
     aresponses,
     authentication_response,
+    caplog,
     upcoming_subscription_pickups_response,
     user_response,
 ):
     """Test getting the next upcoming pickup event associated with an account."""
+    caplog.set_level(logging.DEBUG)
+
     aresponses.add(
         "api.ridwell.com",
         "/",
@@ -117,6 +121,11 @@ async def test_get_next_pickup_event(
         assert pickup_event.pickups[2].product_id == "pickupProduct3"
         assert pickup_event.pickups[2].quantity == 1
         assert pickup_event.pickups[2].category == PickupCategory.ROTATING
+
+        assert any(
+            "Detected assumed rotating pickup: Chocolate" in e.message
+            for e in caplog.records
+        )
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

Our method of detecting rotating pickups is pretty loose: we keep a map of standard/add-on pickups and if a pickup type doesn't exist in it, we assume it's rotating. This "works," but it's based on some fundamentally flawed logic that we can't truly fix (since the API doesn't explicitly show a pickup type's category). This could cause a `RidwellPickupEvent` to erroneously have multiple rotating pickup types.

This may not be a long-term solution, but for now, this PR attempts to be unintrusive and merely logs that we've found a "rotating" pickup so that the logs can help debug.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
