### PR TITLE
Alter cost estimate function to use updated Ridwell API

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-### Calculating a Pickup Event's Estimated Cost
+### Calculating a Pickup Event's Estimated Add-on Cost
 
 ```python
 import asyncio
@@ -200,7 +200,7 @@ async def main() -> None:
         events = await account.async_get_pickup_events()
         # >>> [RidwellPickupEvent(...), ...]
 
-        event_1_cost = await events[0].async_get_estimated_cost()
+        event_1_cost = await events[0].async_get_estimated_addon_cost()
         # >>> 22.00
 
 

--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -212,7 +212,7 @@ class RidwellPickupEvent:
             ),
         )
 
-    async def async_get_estimated_cost(self) -> float:
+    async def async_get_estimated_addon_cost(self) -> float:
         """Get the estimated cost (USD) of this pickup based on its pickup types.
 
         Returns:
@@ -241,7 +241,9 @@ class RidwellPickupEvent:
             },
         )
 
-        return cast(float, resp["data"]["subscriptionPickupQuote"]["totalCents"] / 100)
+        return cast(
+            float, resp["data"]["subscriptionPickupQuote"]["addOnEstimatedCents"] / 100
+        )
 
     async def async_opt_in(self) -> None:
         """Opt in to the pickup event."""

--- a/aioridwell/query.py
+++ b/aioridwell/query.py
@@ -33,7 +33,13 @@ mutation createAuthentication($input: CreateAuthenticationInput!) {
 QUERY_SUBSCRIPTION_PICKUP_QUOTE = """
 query subscriptionPickupQuote($input: SubscriptionPickupQuoteInput!) {
   subscriptionPickupQuote(input: $input) {
-    totalCents
+    addOnEstimatedCents
+    itemizedAvailableCredits {
+      creditCategory
+      amountCents
+      __typename
+    }
+    __typename
   }
 }
 """

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -15,7 +15,7 @@ PASSWORD = "<PASSWORD>"  # noqa: S105
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
             client = await async_get_client(EMAIL, PASSWORD, session=session)

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -15,7 +15,7 @@ PASSWORD = "<PASSWORD>"  # noqa: S105
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     async with ClientSession() as session:
         try:
             client = await async_get_client(EMAIL, PASSWORD, session=session)
@@ -29,11 +29,13 @@ async def main() -> None:
                 _LOGGER.info("Events for account ID %s: %s", account.account_id, events)
 
                 first_event = events[0]
-                estimated_cost = await first_event.async_get_estimated_cost()
+                estimated_addon_cost = (
+                    await first_event.async_get_estimated_addon_cost()
+                )
                 _LOGGER.info(
-                    "Estimated cost for event %s: %s",
+                    "Estimated add-on cost for event %s: %s",
                     first_event.event_id,
-                    estimated_cost,
+                    estimated_addon_cost,
                 )
         except RidwellError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/tests/fixtures/subscription_pickup_quote_response.json
+++ b/tests/fixtures/subscription_pickup_quote_response.json
@@ -1,7 +1,9 @@
 {
   "data": {
     "subscriptionPickupQuote": {
-      "totalCents": 2200
+      "addOnEstimatedCents": 100,
+      "itemizedAvailableCredits": [],
+      "__typename": "SubscriptionPickupQuote"
     }
   }
 }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -310,11 +310,11 @@ async def test_get_pickup_events_cost(
             pickup_events = await account.async_get_pickup_events()
             assert len(pickup_events) == 2
 
-            event_1_cost = await pickup_events[0].async_get_estimated_cost()
-            assert event_1_cost == 22.00
+            event_1_addon_cost = await pickup_events[0].async_get_estimated_addon_cost()
+            assert event_1_addon_cost == 1.00
 
-            event_2_cost = await pickup_events[1].async_get_estimated_cost()
-            assert event_2_cost == 0.00
+            event_2_addon_cost = await pickup_events[1].async_get_estimated_addon_cost()
+            assert event_2_addon_cost == 0.00
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

At some point, the Ridwell API changed the cost estimation method to return the total add-on cost (rather than the total overall cost). This PR fixes—and updates—that method to reflect that change.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
