### PR TITLE
Update standard categories to include new/updated items

### DIFF
--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -36,8 +36,9 @@ PICKUP_CATEGORIES_MAP = {
     "Multi-Layer Plastic": PickupCategory.STANDARD,
     "Paint": PickupCategory.ADD_ON,
     "Plastic Film": PickupCategory.STANDARD,
+    "Recyclable Threads": PickupCategory.STANDARD,
+    "Rewearable Clothes & Shoes": PickupCategory.STANDARD,
     "Styrofoam": PickupCategory.ADD_ON,
-    "Threads": PickupCategory.STANDARD,
 }
 
 

--- a/tests/fixtures/upcoming_subscription_pickups_response.json
+++ b/tests/fixtures/upcoming_subscription_pickups_response.json
@@ -12,7 +12,7 @@
                 "id": "pickupOffer1",
                 "priority": 1,
                 "category": {
-                  "name": "Threads"
+                  "name": "Recyclable Threads"
                 }
               },
               "pickupProduct": {
@@ -47,6 +47,21 @@
               },
               "pickupProduct": {
                 "id": "pickupProduct3"
+              }
+            },
+            "quantity": 1
+          },
+          {
+            "pickupOfferPickupProduct": {
+              "pickupOffer": {
+                "id": "pickupOffer4",
+                "priority": 1,
+                "category": {
+                  "name": "Rewearable Clothes & Shoes"
+                }
+              },
+              "pickupProduct": {
+                "id": "pickupProduct4"
               }
             },
             "quantity": 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -110,8 +110,8 @@ async def test_get_next_pickup_event(
             assert pickup_event.pickup_date == date(2021, 10, 13)
             assert pickup_event.state == EventState.SCHEDULED
 
-            assert len(pickup_event.pickups) == 3
-            assert pickup_event.pickups[0].name == "Threads"
+            assert len(pickup_event.pickups) == 4
+            assert pickup_event.pickups[0].name == "Recyclable Threads"
             assert pickup_event.pickups[0].offer_id == "pickupOffer1"
             assert pickup_event.pickups[0].priority == 1
             assert pickup_event.pickups[0].product_id == "pickupProduct1"
@@ -129,6 +129,12 @@ async def test_get_next_pickup_event(
             assert pickup_event.pickups[2].product_id == "pickupProduct3"
             assert pickup_event.pickups[2].quantity == 1
             assert pickup_event.pickups[2].category == PickupCategory.ROTATING
+            assert pickup_event.pickups[3].name == "Rewearable Clothes & Shoes"
+            assert pickup_event.pickups[3].offer_id == "pickupOffer4"
+            assert pickup_event.pickups[3].priority == 1
+            assert pickup_event.pickups[3].product_id == "pickupProduct4"
+            assert pickup_event.pickups[3].quantity == 1
+            assert pickup_event.pickups[3].category == PickupCategory.STANDARD
 
             assert any(
                 "Detected assumed rotating pickup: Chocolate" in e.message
@@ -234,8 +240,8 @@ async def test_get_pickup_events(
             assert pickup_events[1].pickup_date == date(2021, 10, 27)
             assert pickup_events[1].state == EventState.INITIALIZED
 
-            assert len(pickup_events[0].pickups) == 3
-            assert pickup_events[0].pickups[0].name == "Threads"
+            assert len(pickup_events[0].pickups) == 4
+            assert pickup_events[0].pickups[0].name == "Recyclable Threads"
             assert pickup_events[0].pickups[0].offer_id == "pickupOffer1"
             assert pickup_events[0].pickups[0].priority == 1
             assert pickup_events[0].pickups[0].product_id == "pickupProduct1"
@@ -253,6 +259,12 @@ async def test_get_pickup_events(
             assert pickup_events[0].pickups[2].product_id == "pickupProduct3"
             assert pickup_events[0].pickups[2].quantity == 1
             assert pickup_events[0].pickups[2].category == PickupCategory.ROTATING
+            assert pickup_events[0].pickups[3].name == "Rewearable Clothes & Shoes"
+            assert pickup_events[0].pickups[3].offer_id == "pickupOffer4"
+            assert pickup_events[0].pickups[3].priority == 1
+            assert pickup_events[0].pickups[3].product_id == "pickupProduct4"
+            assert pickup_events[0].pickups[3].quantity == 1
+            assert pickup_events[0].pickups[3].category == PickupCategory.STANDARD
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**
This replaces the previous "Threads" standard category with the new replacements of "Rewearable clothes & shoes" and "Recyclable Threads" options. Both are standard categories in the normal pickup schedule now.

Without this change, the current "Threads" category now appears as a rotating category (which is totally expected, given the fallback mechanism since this category is no longer being included) 

**Does this fix a specific issue?**
Fixes https://github.com/bachya/aioridwell/issues/650

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
