### PR TITLE
feat: Expose featured categories and alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ The `RidwellPickupEvent` object comes with some useful properties:
 - `pickup_date`: the date of the pickup (in `datetime.date` format)
 - `pickups`: a list of `RidwellPickup` objects
 - `state`: an `EventState` enum whose name represents the current state of the pickup event
+- `pickup_offers`: a list of `RidwellPickupOffer` objects representing available categories
+- `featured_category`: the primary featured category for this event (or `None`)
+- `selected_featured_offer`: the currently selected featured offer (or `None`)
+- `featured_alternatives`: a list of alternative featured categories available
+
+The `RidwellPickupOffer` object comes with some useful properties:
+
+- `offer_id`: the Ridwell ID for this offer
+- `category_name`: the display name of the category
+- `category_slug`: the URL-friendly slug for the category
+- `offer_type`: an `OfferType` enum (CORE, ADD_ON, FEATURED_PRIMARY, FEATURED_ALTERNATIVE, BEYOND_THE_BIN)
+- `is_selected`: whether this offer is currently selected for the pickup event
 
 Likewise, the `RidwellPickup` object comes with some useful properties:
 
@@ -160,6 +172,40 @@ Likewise, the `RidwellPickup` object comes with some useful properties:
 - `priority`: the pickup priority
 - `product_id`: the Ridwell ID for this particular product
 - `quantity`: the amount of the product being picked up
+
+### Getting Featured Categories
+
+Each pickup event has a featured (rotating) category and alternative options:
+
+```python
+import asyncio
+
+from aioridwell import async_get_client
+
+
+async def main() -> None:
+    client = await async_get_client("<EMAIL>", "<PASSWORD>")
+
+    accounts = await client.async_get_accounts()
+    for account in accounts.values():
+        events = await account.async_get_pickup_events()
+
+        for event in events:
+            # Get the featured category for this pickup
+            if event.featured_category:
+                print(f"{event.pickup_date}: {event.featured_category.category_name}")
+
+            # Get what's currently selected
+            if event.selected_featured_offer:
+                print(f"  Selected: {event.selected_featured_offer.category_name}")
+
+            # Get available alternatives
+            for alt in event.featured_alternatives:
+                print(f"  Alternative: {alt.category_name}")
+
+
+asyncio.run(main())
+```
 
 ### Opting Into or Out Of a Pickup Event
 

--- a/aioridwell/__init__.py
+++ b/aioridwell/__init__.py
@@ -1,3 +1,12 @@
-"""Define the aiowatttime package."""
+"""Define the aioridwell package."""
 
 from .client import async_get_client  # noqa
+from .model import (  # noqa
+    EventState,
+    OfferType,
+    PickupCategory,
+    RidwellAccount,
+    RidwellPickup,
+    RidwellPickupEvent,
+    RidwellPickupOffer,
+)

--- a/aioridwell/model.py
+++ b/aioridwell/model.py
@@ -27,6 +27,33 @@ class PickupCategory(Enum):
     STANDARD = "standard"
 
 
+class OfferType(Enum):
+    """Define a representation of a pickup offer type."""
+
+    ADD_ON = "ADD_ON"
+    BEYOND_THE_BIN = "BEYOND_THE_BIN"
+    CORE = "CORE"
+    FEATURED_ALTERNATIVE = "FEATURED_ALTERNATIVE"
+    FEATURED_PRIMARY = "FEATURED_PRIMARY"
+    UNKNOWN = "UNKNOWN"
+
+
+def convert_offer_type(offer_type: str) -> OfferType:
+    """Convert a raw offer type string into an OfferType.
+
+    Args:
+        offer_type: A raw offer type.
+
+    Returns:
+        A parsed OfferType object.
+    """
+    try:
+        return OfferType(offer_type)
+    except ValueError:
+        LOGGER.warning("Unknown offer type: %s", offer_type)
+        return OfferType.UNKNOWN
+
+
 PICKUP_CATEGORIES_MAP = {
     "Batteries": PickupCategory.STANDARD,
     "Beyond the Bin": PickupCategory.ADD_ON,
@@ -120,29 +147,53 @@ class RidwellAccount:
             },
         )
 
-        return [
-            RidwellPickupEvent(
-                self._async_request,
-                event_data["id"],
-                datetime.strptime(event_data["pickupOn"], "%Y-%m-%d").date(),
-                [
-                    RidwellPickup(
-                        titlecase(
-                            pickup["pickupOfferPickupProduct"]["pickupOffer"][
-                                "category"
-                            ]["name"]
-                        ),
-                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["id"],
-                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["priority"],
-                        pickup["pickupOfferPickupProduct"]["pickupProduct"]["id"],
-                        pickup["quantity"],
-                    )
-                    for pickup in event_data["pickupProductSelections"]
-                ],
-                convert_pickup_event_state(event_data["state"]),
+        events = []
+        for event_data in resp["data"]["upcomingSubscriptionPickups"]:
+            # Parse pickup product selections (existing functionality)
+            pickups = [
+                RidwellPickup(
+                    titlecase(
+                        pickup["pickupOfferPickupProduct"]["pickupOffer"]["category"][
+                            "name"
+                        ]
+                    ),
+                    pickup["pickupOfferPickupProduct"]["pickupOffer"]["id"],
+                    pickup["pickupOfferPickupProduct"]["pickupOffer"]["priority"],
+                    pickup["pickupOfferPickupProduct"]["pickupProduct"]["id"],
+                    pickup["quantity"],
+                )
+                for pickup in event_data["pickupProductSelections"]
+            ]
+
+            # Parse pickup offers (featured categories and alternatives)
+            selected_offer_id = None
+            if event_data.get("selectedFeaturedOffer"):
+                selected_offer_id = event_data["selectedFeaturedOffer"].get("id")
+
+            pickup_offers = [
+                RidwellPickupOffer(
+                    offer_id=offer["id"],
+                    category_name=titlecase(offer["category"]["name"]),
+                    category_slug=offer["category"]["slug"],
+                    offer_type=convert_offer_type(offer["type"]),
+                    is_selected=(offer["id"] == selected_offer_id),
+                )
+                for offer in event_data.get("pickupOffers", [])
+                if offer.get("category") and offer["category"].get("name")
+            ]
+
+            events.append(
+                RidwellPickupEvent(
+                    self._async_request,
+                    event_data["id"],
+                    datetime.strptime(event_data["pickupOn"], "%Y-%m-%d").date(),
+                    pickups,
+                    convert_pickup_event_state(event_data["state"]),
+                    pickup_offers,
+                )
             )
-            for event_data in resp["data"]["upcomingSubscriptionPickups"]
-        ]
+
+        return events
 
 
 @dataclass(frozen=True)
@@ -177,6 +228,17 @@ class RidwellPickup:
 
 
 @dataclass(frozen=True)
+class RidwellPickupOffer:
+    """Define a Ridwell pickup offer (available category for a pickup event)."""
+
+    offer_id: str
+    category_name: str
+    category_slug: str
+    offer_type: OfferType
+    is_selected: bool = False
+
+
+@dataclass(frozen=True)
 class RidwellPickupEvent:
     """Define a Ridwell pickup event."""
 
@@ -186,6 +248,44 @@ class RidwellPickupEvent:
     pickup_date: date
     pickups: list[RidwellPickup]
     state: EventState
+    pickup_offers: list[RidwellPickupOffer] = field(default_factory=list)
+
+    @property
+    def featured_category(self) -> RidwellPickupOffer | None:
+        """Get the featured (primary) category for this pickup event.
+
+        Returns:
+            The featured category offer, or None if not available.
+        """
+        for offer in self.pickup_offers:
+            if offer.offer_type == OfferType.FEATURED_PRIMARY:
+                return offer
+        return None
+
+    @property
+    def selected_featured_offer(self) -> RidwellPickupOffer | None:
+        """Get the currently selected featured offer for this pickup event.
+
+        Returns:
+            The selected offer, or None if nothing is selected.
+        """
+        for offer in self.pickup_offers:
+            if offer.is_selected:
+                return offer
+        return None
+
+    @property
+    def featured_alternatives(self) -> list[RidwellPickupOffer]:
+        """Get the alternative featured categories available for this pickup event.
+
+        Returns:
+            A list of alternative featured category offers.
+        """
+        return [
+            offer
+            for offer in self.pickup_offers
+            if offer.offer_type == OfferType.FEATURED_ALTERNATIVE
+        ]
 
     async def _async_opt(self, state: EventState) -> None:
         """Define a helper to opt in/out to/from the pickup event.

--- a/aioridwell/query.py
+++ b/aioridwell/query.py
@@ -72,6 +72,7 @@ fragment SubscriptionPickupData on SubscriptionPickup {
     isAutoOptIn
     category {
       slug
+      name
       __typename
     }
     __typename

--- a/tests/fixtures/upcoming_subscription_pickups_response.json
+++ b/tests/fixtures/upcoming_subscription_pickups_response.json
@@ -5,6 +5,43 @@
         "id": "pickup1",
         "state": "scheduled",
         "pickupOn": "2021-10-13",
+        "selectedFeaturedOffer": {
+          "id": "featuredOffer1"
+        },
+        "pickupOffers": [
+          {
+            "id": "coreOffer1",
+            "type": "CORE",
+            "category": {
+              "name": "Batteries",
+              "slug": "batteries"
+            }
+          },
+          {
+            "id": "featuredOffer1",
+            "type": "FEATURED_PRIMARY",
+            "category": {
+              "name": "Chocolate",
+              "slug": "chocolate"
+            }
+          },
+          {
+            "id": "altOffer1",
+            "type": "FEATURED_ALTERNATIVE",
+            "category": {
+              "name": "Coffee Capsules",
+              "slug": "coffee-capsules"
+            }
+          },
+          {
+            "id": "altOffer2",
+            "type": "FEATURED_ALTERNATIVE",
+            "category": {
+              "name": "Corks",
+              "slug": "corks"
+            }
+          }
+        ],
         "pickupProductSelections": [
           {
             "pickupOfferPickupProduct": {
@@ -72,6 +109,7 @@
         "id": "pickup2",
         "state": "initialized",
         "pickupOn": "2021-10-27",
+        "pickupOffers": [],
         "pickupProductSelections": []
       }
     ]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -476,7 +476,8 @@ async def test_featured_categories(
                 == OfferType.FEATURED_PRIMARY
             )
 
-            # Test selected_featured_offer property (returns offer matching selectedFeaturedOffer.id)
+            # Test selected_featured_offer property
+            # (returns offer matching selectedFeaturedOffer.id)
             assert pickup_events[0].selected_featured_offer is not None
             assert pickup_events[0].selected_featured_offer.offer_id == "featuredOffer1"
             assert pickup_events[0].selected_featured_offer.is_selected is True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from aioridwell import async_get_client
 from aioridwell.errors import RidwellError
-from aioridwell.model import EventState, PickupCategory
+from aioridwell.model import EventState, OfferType, PickupCategory, convert_offer_type
 
 
 @pytest.mark.asyncio
@@ -429,3 +429,80 @@ async def test_opt_in(  # pylint: disable=too-many-arguments, too-many-positiona
             assert pickup_events[0].state == EventState.UNKNOWN
 
     aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.asyncio
+async def test_featured_categories(
+    aresponses: ResponsesMockServer,
+    authenticated_ridwell_api_server: ResponsesMockServer,
+    upcoming_subscription_pickups_response: dict[str, Any],
+    user_response: dict[str, Any],
+) -> None:
+    """Test featured category properties on pickup events.
+
+    Args:
+        aresponses: An aresponses server.
+        authenticated_ridwell_api_server: A mocked authenticated Ridwell API server.
+        upcoming_subscription_pickups_response: An API response payload.
+        user_response: An API response payload.
+    """
+    async with authenticated_ridwell_api_server:
+        authenticated_ridwell_api_server.add(
+            "api.ridwell.com",
+            "/",
+            "post",
+            response=aiohttp.web_response.json_response(user_response, status=200),
+        )
+        authenticated_ridwell_api_server.add(
+            "api.ridwell.com",
+            "/",
+            "post",
+            response=aiohttp.web_response.json_response(
+                upcoming_subscription_pickups_response, status=200
+            ),
+        )
+
+        async with aiohttp.ClientSession() as session:
+            client = await async_get_client("user", "password", session=session)
+            accounts = await client.async_get_accounts()
+            account = accounts["accountId1"]
+            pickup_events = await account.async_get_pickup_events()
+
+            # Test featured_category property (returns FEATURED_PRIMARY offer)
+            assert pickup_events[0].featured_category is not None
+            assert pickup_events[0].featured_category.category_name == "Chocolate"
+            assert pickup_events[0].featured_category.offer_type == OfferType.FEATURED_PRIMARY
+
+            # Test selected_featured_offer property (returns offer matching selectedFeaturedOffer.id)
+            assert pickup_events[0].selected_featured_offer is not None
+            assert pickup_events[0].selected_featured_offer.offer_id == "featuredOffer1"
+            assert pickup_events[0].selected_featured_offer.is_selected is True
+
+            # Test featured_alternatives property (returns FEATURED_ALTERNATIVE offers)
+            alternatives = pickup_events[0].featured_alternatives
+            assert len(alternatives) == 2
+            assert alternatives[0].category_name == "Coffee Capsules"
+            assert alternatives[0].offer_type == OfferType.FEATURED_ALTERNATIVE
+            assert alternatives[1].category_name == "Corks"
+            assert alternatives[1].offer_type == OfferType.FEATURED_ALTERNATIVE
+
+            # Test pickup_offers list
+            assert len(pickup_events[0].pickup_offers) == 4
+
+            # Test event without featured offers returns None/empty
+            assert pickup_events[1].featured_category is None
+            assert pickup_events[1].selected_featured_offer is None
+            assert pickup_events[1].featured_alternatives == []
+
+    aresponses.assert_plan_strictly_followed()
+
+
+def test_convert_offer_type_unknown(caplog: Mock) -> None:
+    """Test convert_offer_type with an unknown offer type.
+
+    Args:
+        caplog: A mocked logging utility.
+    """
+    result = convert_offer_type("INVALID_TYPE")
+    assert result == OfferType.UNKNOWN
+    assert any("Unknown offer type: INVALID_TYPE" in e.message for e in caplog.records)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -471,7 +471,10 @@ async def test_featured_categories(
             # Test featured_category property (returns FEATURED_PRIMARY offer)
             assert pickup_events[0].featured_category is not None
             assert pickup_events[0].featured_category.category_name == "Chocolate"
-            assert pickup_events[0].featured_category.offer_type == OfferType.FEATURED_PRIMARY
+            assert (
+                pickup_events[0].featured_category.offer_type
+                == OfferType.FEATURED_PRIMARY
+            )
 
             # Test selected_featured_offer property (returns offer matching selectedFeaturedOffer.id)
             assert pickup_events[0].selected_featured_offer is not None


### PR DESCRIPTION
## Summary

This PR exposes featured (rotating) categories and their alternatives on pickup events. The API already fetches this data via `selectedFeaturedOffer` and `pickupOffers` in the GraphQL query, but it wasn't being exposed in the model.

## Changes

- Add `OfferType` enum for pickup offer types (`CORE`, `ADD_ON`, `FEATURED_PRIMARY`, `FEATURED_ALTERNATIVE`, `BEYOND_THE_BIN`)
- Add `RidwellPickupOffer` dataclass for category offers with fields:
  - `offer_id`, `category_name`, `category_slug`, `offer_type`, `is_selected`
- Add `pickup_offers` field to `RidwellPickupEvent`
- Add helper properties on `RidwellPickupEvent`:
  - `featured_category`: Get the primary featured category
  - `selected_featured_offer`: Get what's currently selected
  - `featured_alternatives`: Get alternative options
- Update query to include `name` in `pickupOffers.category`
- Export new classes from `__init__.py`
- Update README with documentation and usage example

## Use Case

This allows users to see which featured category is available for each pickup, what's currently selected, and what alternatives they can choose. Example:

```python
events = await account.async_get_pickup_events()
for event in events:
    if event.featured_category:
        print(f"{event.pickup_date}: {event.featured_category.category_name}")
    for alt in event.featured_alternatives:
        print(f"  Alternative: {alt.category_name}")
```

## Context

I discovered this while building a [Ridwell skill for Claude Code](https://github.com/daveonkels/ridwell-skill) and needed to access featured category data. Found that the GraphQL query already fetches this information - it just needed to be exposed in the model.

## Test plan

- [ ] Verify `featured_category` returns the `FEATURED_PRIMARY` offer
- [ ] Verify `selected_featured_offer` returns the offer matching `selectedFeaturedOffer.id`
- [ ] Verify `featured_alternatives` returns all `FEATURED_ALTERNATIVE` offers
- [ ] Verify backward compatibility (existing code using `pickups` still works)